### PR TITLE
Roles functionality

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 105 }, uniqueness: { case_sensitive: false }, format: { with: VALID_EMAIL_REGEX }
   has_secure_password
+  is_admin?
 
   before_save { self.email = email.downcase }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ActiveRecord::Base
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 105 }, uniqueness: { case_sensitive: false }, format: { with: VALID_EMAIL_REGEX }
   has_secure_password
-  is_admin?
 
   before_save { self.email = email.downcase }
 end

--- a/db/migrate/20200602173622_add_admin_flag.rb
+++ b/db/migrate/20200602173622_add_admin_flag.rb
@@ -1,0 +1,5 @@
+class AddAdminFlag < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :is_admin, :boolean, :default => false
+  end
+end

--- a/db/migrate/20200602173622_add_admin_flag.rb
+++ b/db/migrate/20200602173622_add_admin_flag.rb
@@ -1,5 +1,5 @@
 class AddAdminFlag < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :is_admin, :boolean, :default => false
+    add_column :users, :is_admin, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_183547) do
+ActiveRecord::Schema.define(version: 2020_06_02_173622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_183547) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_admin", default: false
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.feature User, type: :model do
+  describe 'new user' do
+    it 'will default to non admin' do
+      user = User.create(username: 'user', password: 'password', email: 'email@email.com')
+      expect(User.first.is_admin?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
According to the spec, these roles are required:
- admin
- team_member

This could have been done with constants (or enums), and this approach should be considered if more roles are required. But as the spec only defines 2, a boolean flag is sufficient.